### PR TITLE
Fix/empty store crash

### DIFF
--- a/quotes/store.py
+++ b/quotes/store.py
@@ -17,5 +17,9 @@ class QuoteStore:
         self.path.write_text(json.dumps(quotes, indent=2), encoding="utf-8")
 
     def list_all(self) -> list[Quote]:
-        quotes = json.loads(self.path.read_text(encoding="utf-8"))
+        try:
+            quotes = json.loads(self.path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return []
+
         return [Quote.from_dict(item) for item in quotes]

--- a/quotes/store.py
+++ b/quotes/store.py
@@ -17,9 +17,8 @@ class QuoteStore:
         self.path.write_text(json.dumps(quotes, indent=2), encoding="utf-8")
 
     def list_all(self) -> list[Quote]:
-        try:
-            quotes = json.loads(self.path.read_text(encoding="utf-8"))
-        except FileNotFoundError:
+        if not self.path.exists():
             return []
 
+        quotes = json.loads(self.path.read_text(encoding="utf-8"))
         return [Quote.from_dict(item) for item in quotes]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -25,6 +25,14 @@ def test_list_returns_empty_list_on_new_store(tmp_path):
     assert quotes == []
 
 
+def test_list_all_when_file_missing(tmp_path):
+    store = QuoteStore(tmp_path / "doesnt_exist.json")
+
+    quotes = store.list_all()
+
+    assert quotes == []
+
+
 def test_persistence_across_instances(tmp_path):
     path = tmp_path / "quotes.json"
     store_a = QuoteStore(path)


### PR DESCRIPTION
Fixes #5

Catches FileNotFoundError in list_all() and returns an empty
list instead of crashing. Adds a regression test.